### PR TITLE
Get tests to run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: objective-c
+language: swift
 osx_image: xcode9.3
 xcode_project: libGopher.xcodeproj
 xcode_scheme: libGopher-macOS
+script: "xcodebuild test -project libGopher.xcodeproj -scheme 'libGopher-macOS' | xcpretty -c && exit ${PIPESTATUS[0]}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-language: swift
+language: objective-c
 osx_image: xcode9.3
-script: xcodebuild -scheme libGopher-macOS test
 xcode_project: libGopher.xcodeproj
 xcode_scheme: libGopher-macOS


### PR DESCRIPTION
Travis needs a series of workarounds to correctly build and test swift projects. Specifying obj-c with xctool didn't quite work, so I'm setting xcodebuild with explicit parameters until Travis is fixed. See https://github.com/travis-ci/travis-ci/issues/9003